### PR TITLE
feat(routes): remove not used view permission

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/campaigns/campaigns.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/campaigns/campaigns.routes.js
@@ -7,7 +7,7 @@ import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 
 const meta = {
   featureFlag: FEATURE_FLAGS.CAMPAIGNS,
-  permissions: ['administrator'],
+  permissions: ['no-one-has-this-permission'],
 };
 
 const campaignsRoutes = {

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/helpcenter.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/helpcenter.routes.js
@@ -24,7 +24,7 @@ const PortalsSettingsIndexPage = () =>
 
 const meta = {
   featureFlag: FEATURE_FLAGS.HELP_CENTER,
-  permissions: ['administrator', 'agent', 'knowledge_base_manage'],
+  permissions: ['no-one-has-this-permission'],
 };
 const portalRoutes = [
   {
@@ -87,7 +87,7 @@ const portalRoutes = [
     name: 'portals_new',
     meta: {
       featureFlag: FEATURE_FLAGS.HELP_CENTER,
-      permissions: ['administrator', 'knowledge_base_manage'],
+      permissions: ['no-one-has-this-permission'],
     },
     component: PortalsNew,
   },
@@ -96,7 +96,7 @@ const portalRoutes = [
     name: 'portals_index',
     meta: {
       featureFlag: FEATURE_FLAGS.HELP_CENTER,
-      permissions: ['administrator', 'knowledge_base_manage'],
+      permissions: ['no-one-has-this-permission'],
     },
     component: PortalsIndex,
   },

--- a/app/javascript/dashboard/routes/dashboard/settings/attributes/attributes.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/attributes/attributes.routes.js
@@ -21,7 +21,7 @@ export default {
           component: AttributesHome,
           meta: {
             featureFlag: FEATURE_FLAGS.CUSTOM_ATTRIBUTES,
-            permissions: ['administrator'],
+            permissions: ['no-one-has-this-permission'],
           },
         },
       ],

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/automation.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/automation.routes.js
@@ -21,7 +21,7 @@ export default {
           component: Automation,
           meta: {
             featureFlag: FEATURE_FLAGS.AUTOMATIONS,
-            permissions: ['administrator'],
+            permissions: ['no-one-has-this-permission'],
           },
         },
       ],

--- a/app/javascript/dashboard/routes/dashboard/settings/canned/canned.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/canned/canned.routes.js
@@ -24,7 +24,7 @@ export default {
           name: 'canned_list',
           meta: {
             featureFlag: FEATURE_FLAGS.CANNED_RESPONSES,
-            permissions: [...ROLES, ...CONVERSATION_PERMISSIONS],
+            permissions: ['no-one-has-this-permission'],
           },
           component: CannedHome,
         },

--- a/app/javascript/dashboard/routes/dashboard/settings/customRoles/customRole.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/customRoles/customRole.routes.js
@@ -24,7 +24,7 @@ export default {
               INSTALLATION_TYPES.CLOUD,
               INSTALLATION_TYPES.ENTERPRISE,
             ],
-            permissions: ['administrator'],
+            permissions: ['no-one-has-this-permission'],
           },
           component: CustomRolesHome,
         },

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/integrations.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/integrations.routes.js
@@ -23,7 +23,7 @@ export default {
           component: Index,
           meta: {
             featureFlag: FEATURE_FLAGS.INTEGRATIONS,
-            permissions: ['administrator'],
+            permissions: ['no-one-has-this-permission'],
           },
         },
         {

--- a/app/javascript/dashboard/routes/dashboard/settings/macros/macros.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/macros/macros.routes.js
@@ -22,7 +22,7 @@ export default {
           component: Macros,
           meta: {
             featureFlag: FEATURE_FLAGS.MACROS,
-            permissions: [...ROLES, ...CONVERSATION_PERMISSIONS],
+            permissions: ['no-one-has-this-permission'],
           },
         },
       ],

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/reports.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/reports.routes.js
@@ -153,13 +153,17 @@ export default {
         {
           path: 'sla',
           name: 'sla_reports',
-          meta,
+          meta: {
+            permissions: ['no-one-has-this-permission'],
+          },
           component: SLAReports,
         },
         {
           path: 'csat',
           name: 'csat_reports',
-          meta,
+          meta: {
+            permissions: ['no-one-has-this-permission'],
+          },
           component: CsatResponses,
         },
         {


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request implements a significant refactoring of the frontend routes by disabling access to several unused. The changes focus on restricting access to features that should not be accessible.

Key changes include:

1. Campaigns Module:
   - Updated permissions to restrict access using `no-one-has-this-permission`

2. Help Center Module:
   - Restricted access to portal routes and settings
   - Modified permissions for portal management features

3. Settings Module:
   - Disabled access to several features by updating permissions:
     - Custom Attributes
     - Automation settings
     - Canned Responses
     - Custom Roles
     - Integrations
     - Macros

4. Reports Module:
   - Disabled access to SLA and CSAT reports

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I have verified these changes by testing it locally, and see that the disabled views were not present.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
