### PR TITLE
fix(notification_forward_service): Replace OpenStruct with NotificationChannel and NotificationMessage

### DIFF
--- a/app/services/forward_notification_service.rb
+++ b/app/services/forward_notification_service.rb
@@ -48,7 +48,7 @@ class ForwardNotificationService
     when 'whatsapp'
       send_whatsapp_notifications(target_chats)
     else
-      Rails.logger.warn "Unknown notification channel: #{channel}"
+      Rails.logger.warn "Not implemented notification channel: #{channel}"
     end
   end
 
@@ -61,10 +61,16 @@ class ForwardNotificationService
       if default_api_key.present?
         whatsapp_channel = create_whapi_channel(default_api_key)
       else
-        Rails.logger.warn "No DEFAULT_WHAPI_CHANNEL_TOKEN found"
-        return
+        Rails.logger.error "Account #{@account.id} with no whapi channel and no default whapi channel token defined"
+      return
       end
     end
+
+    # Validate that the channel has proper configuration
+    unless whatsapp_channel&.provider_config&.dig('api_key').present?
+      Rails.logger.warn "WhatsApp channel missing API key for account #{@account.id}"
+      return
+    end  
 
     target_chats.each do |chat_id|
       # Send to the WhatsApp channel
@@ -73,37 +79,47 @@ class ForwardNotificationService
   end
 
   def send_via_whatsapp_channel(whatsapp_channel, target_chat, notification_message)
-    # Create a message object that the WhatsApp channel can send
-    message_object = OpenStruct.new(
-      content: notification_message,
-      content_type: 'text',
-      message_type: 'outgoing',
-      private: false,
-      attachments: [],
-      content_attributes: {}
-    )
+    return if whatsapp_channel.nil? || target_chat.blank?
 
-    # Add the outgoing_content method
-    def message_object.outgoing_content
-      content
-    end
+    # Create a proper message object for notification forwarding
+    message_object = NotificationMessage.new(notification_message)
 
-    # Send the message using the WhatsApp channel
-    message_id = whatsapp_channel.send_message(target_chat, message_object)
-
-    Rails.logger.info "WhatsApp notification sent successfully to #{target_chat}. Message ID: #{message_id}"
+    # Create the WhapiService instance and send the message
+    whapi_service = Whatsapp::Providers::WhapiService.new(whatsapp_channel: whatsapp_channel)
+    whapi_service.send_message(target_chat, message_object)
 
   rescue StandardError => e
     Rails.logger.error "Failed to send WhatsApp notification to #{target_chat}: #{e.message}"
   end
 
   def create_whapi_channel(api_key)
-    whatsapp_channel = OpenStruct.new(
+    Rails.logger.error "Creating whapi channel with api key: #{api_key}"
+    # Create a minimal Channel::Whatsapp instance with only the API key
+    Channel::Whatsapp.new(
       provider: 'whapi',
-      provider_config: { 'api_key' => api_key }
+      provider_config: {
+        'api_key' => api_key
+      },
+      account: @account
     )
-    
-    Whatsapp::Providers::WhapiService.new(whatsapp_channel: whatsapp_channel)
+  end
+
+  # Message object for notification forwarding
+  class NotificationMessage
+    attr_reader :content, :content_type, :message_type, :private, :attachments, :content_attributes
+
+    def initialize(content)
+      @content = content
+      @content_type = 'text'
+      @message_type = 'outgoing'
+      @private = false
+      @attachments = []
+      @content_attributes = {}
+    end
+
+    def outgoing_content
+      content
+    end
   end
 
   def find_notification_config


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will change the OpenStruck class with an specific channel instance to send the notification message, right now is just WHAPI. 

UnitTest were also updated.

ClickUp ticket =CU-86abjrc3c

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Local Testing | Unit tests


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
