### PR TITLE
Prevent duplicate reauthorization emails

### DIFF
--- a/app/models/concerns/reauthorizable.rb
+++ b/app/models/concerns/reauthorizable.rb
@@ -37,6 +37,9 @@ module Reauthorizable
   # Performed automatically if error threshold is breached
   # could used to manually prompt reauthorization if auth scope changes
   def prompt_reauthorization!
+    # Prevent sending duplicate emails if reauthorization is already flagged
+    return if reauthorization_required?
+
     ::Redis::Alfred.set(reauthorization_required_key, true)
 
     reauthorization_handlers[self.class.name]&.call(self)

--- a/spec/models/concerns/reauthorizable_shared.rb
+++ b/spec/models/concerns/reauthorizable_shared.rb
@@ -85,6 +85,23 @@ shared_examples_for 'reauthorizable' do
         expect(AdministratorNotifications::ChannelNotificationsMailer).to have_received(:with).with(account: obj.account)
       end
     end
+
+    it 'does not send duplicate emails when called multiple times' do
+      # First call should send email
+      obj.prompt_reauthorization!
+
+      # Second call should NOT send another email
+      obj.prompt_reauthorization!
+
+      # Verify mailer was only called once (not twice)
+      if model.to_s == 'AutomationRule'
+        expect(AdministratorNotifications::AccountNotificationMailer).to have_received(:with).with(account: obj.account).once
+      elsif model.to_s == 'Integrations::Hook'
+        expect(AdministratorNotifications::IntegrationsNotificationMailer).to have_received(:with).with(account: obj.account).once
+      else
+        expect(AdministratorNotifications::ChannelNotificationsMailer).to have_received(:with).with(account: obj.account).once
+      end
+    end
   end
 
   it 'reauthorized!' do
@@ -99,5 +116,53 @@ shared_examples_for 'reauthorizable' do
     # authorization errors are reset
     expect(obj.authorization_error_count).to eq 0
     expect(obj.reauthorization_required?).to be false
+  end
+
+  context 'complete reauthorization lifecycle' do
+    before do
+      # Setup mailer mocks based on model type
+      if model.to_s == 'AutomationRule'
+        setup_automation_rule_mailer(obj)
+      elsif model.to_s == 'Integrations::Hook'
+        setup_integrations_hook_mailer(obj)
+      else
+        setup_channel_mailer(obj)
+      end
+    end
+
+    it 'allows sending a new email after reconnection and subsequent expiration' do
+      # Phase 1: Channel expires - should send email
+      obj.authorization_error!
+      obj.prompt_reauthorization!
+      expect(obj.reauthorization_required?).to be true
+
+      # Verify first email was sent
+      if model.to_s == 'AutomationRule'
+        expect(AdministratorNotifications::AccountNotificationMailer).to have_received(:with).with(account: obj.account).once
+      elsif model.to_s == 'Integrations::Hook'
+        expect(AdministratorNotifications::IntegrationsNotificationMailer).to have_received(:with).with(account: obj.account).once
+      else
+        expect(AdministratorNotifications::ChannelNotificationsMailer).to have_received(:with).with(account: obj.account).once
+      end
+
+      # Phase 2: User reconnects - clears the flag
+      obj.reauthorized!
+      expect(obj.reauthorization_required?).to be false
+      expect(obj.authorization_error_count).to eq 0
+
+      # Phase 3: Channel expires again - should send a NEW email
+      obj.authorization_error!
+      obj.prompt_reauthorization!
+      expect(obj.reauthorization_required?).to be true
+
+      # Verify second email was sent (total of 2 calls)
+      if model.to_s == 'AutomationRule'
+        expect(AdministratorNotifications::AccountNotificationMailer).to have_received(:with).with(account: obj.account).twice
+      elsif model.to_s == 'Integrations::Hook'
+        expect(AdministratorNotifications::IntegrationsNotificationMailer).to have_received(:with).with(account: obj.account).twice
+      else
+        expect(AdministratorNotifications::ChannelNotificationsMailer).to have_received(:with).with(account: obj.account).twice
+      end
+    end
   end
 end


### PR DESCRIPTION
Added a guard in prompt_reauthorization! to avoid sending duplicate emails if reauthorization is already required. Updated shared examples to test that duplicate emails are not sent and verified the full reauthorization lifecycle, ensuring emails are only sent once per expiration event.

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
ClickUp ticket = [CU-EXAMPLE](url)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
