### PR TITLE
feat: add RAG knowledge base pipeline with Weaviate Cloud

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -189,6 +189,11 @@ gem 'iso-639'
 gem 'ruby-openai'
 gem 'ai-agents', '>= 0.4.3'
 
+# RAG Knowledge Base
+gem 'weaviate-ruby', '>= 0.9.0'
+gem 'pdf-reader'
+gem 'docx'
+
 # TODO: Move this gem as a dependency of ai-agents
 gem 'ruby_llm-schema'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (2.0.1)
     actioncable (7.1.5.2)
       actionpack (= 7.1.5.2)
       activesupport (= 7.1.5.2)
@@ -126,6 +127,7 @@ GEM
       jbuilder (~> 2)
       rails (>= 4.2, < 7.2)
       selectize-rails (~> 0.6)
+    afm (1.0.0)
     ai-agents (0.4.3)
       ruby_llm (~> 1.3)
     annotate (3.2.0)
@@ -225,6 +227,9 @@ GEM
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)
     docile (1.4.1)
+    docx (0.10.0)
+      nokogiri (~> 1.13, >= 1.13.0)
+      rubyzip (>= 2.0, < 4)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (3.1.2)
@@ -324,6 +329,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    fiber-storage (1.0.1)
     flag_shih_tzu (0.3.23)
     foreman (0.87.2)
     fugit (1.11.1)
@@ -395,6 +401,16 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
+    graphlient (0.8.0)
+      faraday (~> 2.0)
+      graphql-client
+    graphql (2.5.22)
+      base64
+      fiber-storage
+      logger
+    graphql-client (0.26.0)
+      activesupport (>= 3.0)
+      graphql (>= 1.13.0)
     groupdate (6.2.1)
       activesupport (>= 5.2)
     grpc (1.72.0)
@@ -418,6 +434,7 @@ GEM
     hana (1.3.7)
     hash_diff (1.1.1)
     hashdiff (1.1.0)
+    hashery (2.1.2)
     hashie (5.0.0)
     html2text (0.4.0)
       nokogiri (>= 1.0, < 2.0)
@@ -624,6 +641,12 @@ GEM
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
+    pdf-reader (2.15.1)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     pg (1.5.3)
     pg_search (2.3.6)
       activerecord (>= 5.2)
@@ -789,6 +812,7 @@ GEM
       faraday (>= 1)
       faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
+    ruby-rc4 (0.1.5)
     ruby-saml (1.18.1)
       nokogiri (>= 1.13.10)
       rexml
@@ -810,6 +834,7 @@ GEM
     ruby_llm-schema (0.1.0)
     ruby_parser (3.20.0)
       sexp_processor (~> 4.16)
+    rubyzip (3.2.2)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -921,6 +946,8 @@ GEM
       i18n
     timeout (0.4.3)
     trailblazer-option (0.1.2)
+    ttfunk (1.8.0)
+      bigdecimal (~> 3.1)
     twilio-ruby (7.6.0)
       faraday (>= 0.9, < 3.0)
       jwt (>= 1.5, < 3.0)
@@ -956,6 +983,9 @@ GEM
       zeitwerk (~> 2.2)
     warden (1.2.9)
       rack (>= 2.0.9)
+    weaviate-ruby (0.9.2)
+      faraday (>= 2.0.1, < 3.0)
+      graphlient (>= 0.7.0, < 0.9.0)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -1019,6 +1049,7 @@ DEPENDENCIES
   devise-secure_password!
   devise-two-factor (>= 5.0.0)
   devise_token_auth (>= 1.2.3)
+  docx
   dotenv-rails (>= 3.0.0)
   down
   elastic-apm
@@ -1069,6 +1100,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection (~> 1.0, >= 1.0.2)
   omniauth-saml
   opensearch-ruby
+  pdf-reader
   pg
   pg_search
   pgvector
@@ -1126,6 +1158,7 @@ DEPENDENCIES
   uglifier
   valid_email2
   vite_rails
+  weaviate-ruby (>= 0.9.0)
   web-console (>= 4.2.1)
   web-push (>= 3.0.1)
   webmock
@@ -1133,7 +1166,7 @@ DEPENDENCIES
   working_hours
 
 RUBY VERSION
-   ruby 3.4.4p34
+  ruby 3.4.4p34
 
 BUNDLED WITH
-   2.5.16
+  4.0.8

--- a/app/controllers/api/v1/accounts/knowledge_bases_controller.rb
+++ b/app/controllers/api/v1/accounts/knowledge_bases_controller.rb
@@ -2,8 +2,8 @@ class Api::V1::Accounts::KnowledgeBasesController < Api::V1::Accounts::BaseContr
   before_action :fetch_knowledge_base, only: [:show, :update, :destroy]
 
   def index
-    @knowledge_bases = Current.account.knowledge_bases.includes(files_attachments: :blob)
-    render json: knowledge_bases_with_files
+    @knowledge_bases = Current.account.knowledge_bases
+    render json: @knowledge_bases.map { |kb| knowledge_base_response(kb) }
   end
 
   def show
@@ -14,7 +14,8 @@ class Api::V1::Accounts::KnowledgeBasesController < Api::V1::Accounts::BaseContr
     @knowledge_base = Current.account.knowledge_bases.new(knowledge_base_params)
 
     if @knowledge_base.save
-      process_attachments if has_file_attachment?
+      # Enqueue with small delay to ensure blob upload transaction is committed
+      KnowledgeBaseProcessingJob.set(wait: 3.seconds).perform_later(@knowledge_base.id)
       render json: knowledge_base_response(@knowledge_base), status: :created
     else
       render json: @knowledge_base.errors, status: :unprocessable_entity
@@ -23,7 +24,6 @@ class Api::V1::Accounts::KnowledgeBasesController < Api::V1::Accounts::BaseContr
 
   def update
     if @knowledge_base.update(knowledge_base_params)
-      process_attachments if has_file_attachment?
       render json: knowledge_base_response(@knowledge_base)
     else
       render json: @knowledge_base.errors, status: :unprocessable_entity
@@ -31,38 +31,29 @@ class Api::V1::Accounts::KnowledgeBasesController < Api::V1::Accounts::BaseContr
   end
 
   def destroy
+    # Clean up Weaviate Cloud chunks before deleting the record
+    KnowledgeBase::WeaviateService.delete_by_knowledge_base(knowledge_base: @knowledge_base)
     @knowledge_base.destroy!
     head :ok
   end
+
+  # NOTE: No search endpoint here. Querying Weaviate for RAG happens
+  # in the ChatsCommerce Python backend during conversations.
 
   private
 
   def fetch_knowledge_base
     @knowledge_base = Current.account.knowledge_bases.find_by(id: params[:id])
+    head :not_found unless @knowledge_base
   end
 
   def knowledge_base_params
     params.require(:knowledge_base).permit(:name, :source_type, :url)
   end
 
-  def has_file_attachment?
-    params[:file_blob_id].present?
-  end
-
-  def process_attachments
-    return unless params[:file_blob_id]
-
-    blob = ActiveStorage::Blob.find_by(id: params[:file_blob_id])
-    @knowledge_base.files.attach(blob) if blob
-  end
-
-  def knowledge_bases_with_files
-    @knowledge_bases.map do |kb|
-      kb.as_json.merge(files: kb.file_base_data)
-    end
-  end
-
   def knowledge_base_response(kb)
-    kb.as_json.merge(files: kb.file_base_data)
+    # as_json returns status as integer (0,1,2,3). Override with the string
+    # name so the frontend can compare against 'pending', 'processing', etc.
+    kb.as_json.merge(status: kb.status)
   end
 end

--- a/app/javascript/dashboard/featureFlags.js
+++ b/app/javascript/dashboard/featureFlags.js
@@ -41,6 +41,7 @@ export const FEATURE_FLAGS = {
   CAPTAIN_V2: 'captain_integration_v2',
   SAML: 'saml',
   QUOTED_EMAIL_REPLY: 'quoted_email_reply',
+  PROMPTS: 'prompts',
 };
 
 export const PREMIUM_FEATURES = [

--- a/app/javascript/dashboard/helper/actionCable.js
+++ b/app/javascript/dashboard/helper/actionCable.js
@@ -36,6 +36,7 @@ class ActionCableConnector extends BaseActionCableConnector {
       'conversation.updated': this.onConversationUpdated,
       'account.cache_invalidated': this.onCacheInvalidate,
       'copilot.message.created': this.onCopilotMessageCreated,
+      'knowledge_base.processed': this.onKnowledgeBaseProcessed,
     };
   }
 
@@ -218,6 +219,11 @@ class ActionCableConnector extends BaseActionCableConnector {
     this.app.$store.dispatch('labels/revalidate', { newKey: keys.label });
     this.app.$store.dispatch('inboxes/revalidate', { newKey: keys.inbox });
     this.app.$store.dispatch('teams/revalidate', { newKey: keys.team });
+  };
+
+  // eslint-disable-next-line class-methods-use-this
+  onKnowledgeBaseProcessed = data => {
+    emitter.emit(BUS_EVENTS.KNOWLEDGE_BASE_PROCESSED, data);
   };
 }
 

--- a/app/javascript/dashboard/i18n/locale/en/prompts.json
+++ b/app/javascript/dashboard/i18n/locale/en/prompts.json
@@ -92,6 +92,12 @@
       "IMAGE": "Image",
       "UNKNOWN": "Unknown"
     },
+    "STATUS": {
+      "PENDING": "Pending...",
+      "PROCESSING": "Processing...",
+      "PROCESSED": "Added",
+      "FAILED": "Failed"
+    },
     "DATE": {
       "TODAY": "Added today",
       "YESTERDAY": "Added yesterday",
@@ -131,6 +137,9 @@
     },
     "URL": {
       "UPLOAD_ERROR": "Failed to process URL. Please check the URL and try again."
+    },
+    "UPLOAD": {
+      "SUPPORTED_TYPES": "Supported: PDF, DOC, DOCX, TXT, CSV, XLS, XLSX, JPG, PNG, GIF, WEBP"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/locale/es/prompts.json
+++ b/app/javascript/dashboard/i18n/locale/es/prompts.json
@@ -89,6 +89,12 @@
       "IMAGE": "Imagen",
       "UNKNOWN": "Desconocido"
     },
+    "STATUS": {
+      "PENDING": "Pendiente...",
+      "PROCESSING": "Procesando...",
+      "PROCESSED": "Agregado",
+      "FAILED": "Fallido"
+    },
     "DATE": {
       "TODAY": "Añadido hoy",
       "YESTERDAY": "Añadido ayer",
@@ -128,6 +134,9 @@
     },
     "URL": {
       "UPLOAD_ERROR": "Error al procesar la URL. Por favor verifica la URL e intenta de nuevo."
+    },
+    "UPLOAD": {
+      "SUPPORTED_TYPES": "Soportados: PDF, DOC, DOCX, TXT, CSV, XLS, XLSX, JPG, PNG, GIF, WEBP"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/locale_custom/en/prompts.json
+++ b/app/javascript/dashboard/i18n/locale_custom/en/prompts.json
@@ -1,7 +1,7 @@
 {
   "KNOWLEDGE_BASE_PAGE": {
-    "TITLE": "Prompts",
-    "DESCRIPTION": "Configure prompts for your account. These prompts can be used in the composer to quickly write a message.",
+    "TITLE": "Knowledge Base",
+    "DESCRIPTION": "Manage your knowledge base. Add knowledge sources to help your agents respond faster and more accurately.",
     "ADD_BUTTON": "Add prompt",
     "ADD_KNOWLEDGE_SOURCE_BUTTON": "Add knowledge source",
     "KNOWLEDGE_SOURCE": {
@@ -89,6 +89,12 @@
       "IMAGE": "Image",
       "UNKNOWN": "Unknown"
     },
+    "STATUS": {
+      "PENDING": "Pending...",
+      "PROCESSING": "Processing...",
+      "PROCESSED": "Added",
+      "FAILED": "Failed"
+    },
     "DATE": {
       "TODAY": "Added today",
       "YESTERDAY": "Added yesterday",
@@ -128,6 +134,9 @@
     },
     "URL": {
       "UPLOAD_ERROR": "Failed to process URL. Please check the URL and try again."
+    },
+    "UPLOAD": {
+      "SUPPORTED_TYPES": "Supported: PDF, DOC, DOCX, TXT, CSV, XLS, XLSX, JPG, PNG, GIF, WEBP"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/locale_custom/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale_custom/en/settings.json
@@ -320,6 +320,7 @@
     "CUSTOM_ATTRIBUTES": "Custom Attributes",
     "AUTOMATION": "Automation",
     "MACROS": "Macros",
+    "KNOWLEDGE_BASE": "Knowledge Base",
     "TEAMS": "Teams",
     "BILLING": "Billing",
     "CUSTOM_VIEWS_FOLDER": "Folders",

--- a/app/javascript/dashboard/i18n/locale_custom/es/prompts.json
+++ b/app/javascript/dashboard/i18n/locale_custom/es/prompts.json
@@ -1,7 +1,7 @@
 {
   "KNOWLEDGE_BASE_PAGE": {
-    "TITLE": "Prompts",
-    "DESCRIPTION": "Configura los prompts para tu cuenta. Estos prompts se pueden usar en el compositor para escribir rápidamente un mensaje.",
+    "TITLE": "Base de Conocimiento",
+    "DESCRIPTION": "Administra tu base de conocimiento. Añade fuentes de conocimiento para ayudar a tus agentes a responder más rápido y con mayor precisión.",
     "ADD_BUTTON": "Añadir prompt",
     "ADD_KNOWLEDGE_SOURCE_BUTTON": "Añadir fuente de conocimiento",
     "KNOWLEDGE_SOURCE": {
@@ -89,6 +89,12 @@
       "IMAGE": "Imagen",
       "UNKNOWN": "Desconocido"
     },
+    "STATUS": {
+      "PENDING": "Pendiente...",
+      "PROCESSING": "Procesando...",
+      "PROCESSED": "Agregado",
+      "FAILED": "Fallido"
+    },
     "DATE": {
       "TODAY": "Añadido hoy",
       "YESTERDAY": "Añadido ayer",
@@ -128,6 +134,9 @@
     },
     "URL": {
       "UPLOAD_ERROR": "Error al procesar la URL. Por favor verifica la URL e intenta de nuevo."
+    },
+    "UPLOAD": {
+      "SUPPORTED_TYPES": "Soportados: PDF, DOC, DOCX, TXT, CSV, XLS, XLSX, JPG, PNG, GIF, WEBP"
     }
   }
 } 

--- a/app/javascript/dashboard/i18n/locale_custom/es/settings.json
+++ b/app/javascript/dashboard/i18n/locale_custom/es/settings.json
@@ -320,6 +320,7 @@
     "CUSTOM_ATTRIBUTES": "Atributos personalizados",
     "AUTOMATION": "Automatización",
     "MACROS": "Macros",
+    "KNOWLEDGE_BASE": "Base de Conocimiento",
     "TEAMS": "Equipos",
     "BILLING": "Facturación",
     "CUSTOM_VIEWS_FOLDER": "Carpetas",

--- a/app/javascript/dashboard/routes/dashboard/settings/prompts/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/prompts/Index.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useStore } from 'vuex';
 import BaseSettingsHeader from '../components/BaseSettingsHeader.vue';
@@ -9,6 +9,8 @@ import Modal from 'dashboard/components/Modal.vue';
 import GalleryView from 'dashboard/components/widgets/conversation/components/GalleryView.vue';
 import { useAlert } from 'dashboard/composables';
 import Auth from 'dashboard/api/auth';
+import { emitter } from 'shared/helpers/mitt';
+import { BUS_EVENTS } from 'shared/constants/busEvents';
 
 const { t } = useI18n();
 const store = useStore();
@@ -35,6 +37,8 @@ const getAuthHeaders = () => {
   }
   return headers;
 };
+
+let pollInterval = null;
 
 const fetchKnowledgeSources = async () => {
   loadingKnowledgeSources.value = true;
@@ -179,8 +183,31 @@ const onKnowledgeSourceAdded = () => {
   fetchKnowledgeSources();
 };
 
+const onKnowledgeBaseProcessed = () => {
+  fetchKnowledgeSources();
+};
+
+// Auto-poll while any KB is pending/processing, stop when all are done
+watch(knowledgeSources, sources => {
+  const hasProcessing = sources.some(
+    s => s.status === 'pending' || s.status === 'processing'
+  );
+  if (hasProcessing && !pollInterval) {
+    pollInterval = setInterval(() => fetchKnowledgeSources(), 5000);
+  } else if (!hasProcessing && pollInterval) {
+    clearInterval(pollInterval);
+    pollInterval = null;
+  }
+});
+
 onMounted(() => {
   fetchKnowledgeSources();
+  emitter.on(BUS_EVENTS.KNOWLEDGE_BASE_PROCESSED, onKnowledgeBaseProcessed);
+});
+
+onUnmounted(() => {
+  emitter.off(BUS_EVENTS.KNOWLEDGE_BASE_PROCESSED, onKnowledgeBaseProcessed);
+  if (pollInterval) clearInterval(pollInterval);
 });
 </script>
 
@@ -232,9 +259,37 @@ onMounted(() => {
                 {{ source.name }}
               </p>
               <p class="text-sm text-slate-600 dark:text-slate-400">
-                {{ getSourceTypeDisplay(source.source_type) }} &bull;
-                {{ formatDate(source.created_at) }}
+                {{
+                  `${getSourceTypeDisplay(source.source_type)} \u2022 ${formatDate(source.created_at)}`
+                }}
               </p>
+              <span
+                v-if="
+                  source.status === 'pending' || source.status === 'processing'
+                "
+                class="inline-flex items-center gap-1 text-xs text-yellow-600 dark:text-yellow-400"
+              >
+                <i class="i-lucide-loader-2 animate-spin w-3 h-3" />
+                {{
+                  source.status === 'pending'
+                    ? t('KNOWLEDGE_SOURCE.STATUS.PENDING')
+                    : t('KNOWLEDGE_SOURCE.STATUS.PROCESSING')
+                }}
+              </span>
+              <span
+                v-else-if="source.status === 'failed'"
+                class="inline-flex items-center gap-1 text-xs text-red-600 dark:text-red-400"
+              >
+                <i class="i-lucide-alert-circle w-3 h-3" />
+                {{ t('KNOWLEDGE_SOURCE.STATUS.FAILED') }}
+              </span>
+              <span
+                v-else-if="source.status === 'processed'"
+                class="inline-flex items-center gap-1 text-xs text-green-600 dark:text-green-400"
+              >
+                <i class="i-lucide-check-circle w-3 h-3" />
+                {{ t('KNOWLEDGE_SOURCE.STATUS.PROCESSED') }}
+              </span>
             </div>
           </div>
           <NextButton
@@ -285,7 +340,7 @@ onMounted(() => {
           <NextButton slate outline @click="cancelDelete">
             {{ t('KNOWLEDGE_SOURCE.DELETE_CONFIRM.CANCEL') }}
           </NextButton>
-          <NextButton variant="danger" @click="deleteKnowledgeSource">
+          <NextButton ruby @click="deleteKnowledgeSource">
             {{ t('KNOWLEDGE_SOURCE.DELETE_CONFIRM.DELETE') }}
           </NextButton>
         </div>

--- a/app/javascript/dashboard/routes/dashboard/settings/prompts/components/AddKnowledgeSource.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/prompts/components/AddKnowledgeSource.vue
@@ -19,80 +19,62 @@ defineProps({
 
 const emit = defineEmits(['close', 'refresh']);
 
+const IMAGE_CONTENT_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/bmp',
+  'image/webp',
+];
+
 const { t } = useI18n();
 const store = useStore();
 const accountId = ref(store.getters.getCurrentAccountId);
 
-const selectedSourceType = ref('webpage');
 const fileUploadInput = ref(null);
-const webpageUrl = ref('');
-const crawlSubpages = ref(false);
 const isLoading = ref(false);
-
-const selectSourceType = type => {
-  selectedSourceType.value = type;
-};
 
 const openFileBrowser = () => {
   fileUploadInput.value.click();
 };
 
 const closeModal = () => {
-  // Reset form state
-  selectedSourceType.value = 'webpage';
-  webpageUrl.value = '';
-  crawlSubpages.value = false;
   isLoading.value = false;
   emit('close');
 };
 
+// Auto-detect source type from file content type
+const detectSourceType = file => {
+  return IMAGE_CONTENT_TYPES.includes(file.type) ? 'image' : 'file';
+};
+
 // Create knowledge base record via API
-const createKnowledgeBase = async (name, blobId, url = null) => {
-  try {
-    const requestBody = {
-      knowledge_base: {
-        name,
-        source_type: selectedSourceType.value,
-        url,
-      },
-      file_blob_id: blobId,
-    };
+const createKnowledgeBase = async (name, sourceType, blobId, url) => {
+  const authData = Auth.getAuthData();
+  const headers = { 'Content-Type': 'application/json' };
 
-    // Get auth headers from the auth system
-    const authData = Auth.getAuthData();
+  if (authData) {
+    headers['access-token'] = authData['access-token'];
+    headers['token-type'] = authData['token-type'];
+    headers.client = authData.client;
+    headers.expiry = authData.expiry;
+    headers.uid = authData.uid;
+  }
 
-    const headers = {
-      'Content-Type': 'application/json',
-    };
-
-    if (authData) {
-      headers['access-token'] = authData['access-token'];
-      headers['token-type'] = authData['token-type'];
-      headers.client = authData.client;
-      headers.expiry = authData.expiry;
-      headers.uid = authData.uid;
+  const response = await fetch(
+    `/api/v1/accounts/${accountId.value}/knowledge_bases`,
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        knowledge_base: { name, source_type: sourceType, url },
+        file_blob_id: blobId,
+      }),
     }
+  );
 
-    const response = await fetch(
-      `/api/v1/accounts/${accountId.value}/knowledge_bases`,
-      {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(requestBody),
-      }
-    );
-
-    if (response.ok) {
-      await response.json();
-      useAlert(t('KNOWLEDGE_SOURCE.SUCCESS_MESSAGE'));
-      closeModal();
-      emit('refresh'); // Refresh the knowledge sources list
-    } else {
-      await response.json();
-      throw new Error('Failed to create knowledge source');
-    }
-  } catch (error) {
-    useAlert(t('KNOWLEDGE_SOURCE.CREATE_ERROR'));
+  if (!response.ok) {
+    throw new Error('Failed to create knowledge source');
   }
 };
 
@@ -104,9 +86,13 @@ const onFileChange = async event => {
   if (checkFileSizeLimit(file, MAXIMUM_FILE_UPLOAD_SIZE)) {
     isLoading.value = true;
     try {
+      const sourceType = detectSourceType(file);
       const { blobId, fileUrl } = await uploadFile(file, accountId.value);
-      await createKnowledgeBase(file.name, blobId, fileUrl);
-    } catch (error) {
+      await createKnowledgeBase(file.name, sourceType, blobId, fileUrl);
+      useAlert(t('KNOWLEDGE_SOURCE.SUCCESS_MESSAGE'));
+      closeModal();
+      emit('refresh');
+    } catch {
       useAlert(t('KNOWLEDGE_SOURCE.FILE.UPLOAD_ERROR'));
     } finally {
       isLoading.value = false;
@@ -120,46 +106,17 @@ const onFileChange = async event => {
     fileUploadInput.value.value = '';
   }
 };
-
-// Handle webpage URL submission
-const onUrlSubmit = async () => {
-  if (!webpageUrl.value.trim()) {
-    useAlert(t('KNOWLEDGE_SOURCE.WEBPAGE.URL_REQUIRED'));
-    return;
-  }
-
-  isLoading.value = true;
-  try {
-    await createKnowledgeBase(webpageUrl.value, null, webpageUrl.value);
-  } catch (error) {
-    useAlert(t('KNOWLEDGE_SOURCE.URL.UPLOAD_ERROR'));
-  } finally {
-    isLoading.value = false;
-  }
-};
-
-// Handle image URL submission (currently unused but may be needed for future URL image uploads)
-// const onImageUrlSubmit = async url => {
-//   isLoading.value = true;
-//   try {
-//     const { blobId } = await uploadExternalImage(url, accountId.value);
-//     await createKnowledgeBase(url, blobId, url);
-//   } catch (error) {
-//     useAlert(t('KNOWLEDGE_SOURCE.URL.UPLOAD_ERROR'));
-//   } finally {
-//     isLoading.value = false;
-//   }
-// };
 </script>
 
 <template>
   <Modal :show="show" :on-close="closeModal" size="medium">
     <div class="flex flex-col">
-      <!-- Hidden file input -->
+      <!-- Hidden file input (accepts both documents and images) -->
       <input
         ref="fileUploadInput"
         type="file"
         class="hidden"
+        accept=".pdf,.doc,.docx,.txt,.csv,.xls,.xlsx,.jpg,.jpeg,.png,.gif,.bmp,.webp"
         @change="onFileChange"
       />
 
@@ -168,114 +125,7 @@ const onUrlSubmit = async () => {
 
       <!-- Modal Body -->
       <div class="p-6">
-        <!-- Source Type Selection -->
-        <div class="mb-6">
-          <h3
-            class="text-sm font-medium text-slate-900 dark:text-slate-100 mb-3"
-          >
-            {{ t('KNOWLEDGE_SOURCE.CHOOSE_TYPE') }}
-          </h3>
-          <div class="grid grid-cols-3 gap-3">
-            <!-- Webpage Option -->
-            <div
-              class="flex flex-col items-center p-4 border-2 rounded-lg cursor-pointer transition-colors"
-              :class="{
-                'border-woot-500 bg-woot-50 dark:bg-woot-900/20':
-                  selectedSourceType === 'webpage',
-                'border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600':
-                  selectedSourceType !== 'webpage',
-              }"
-              @click="selectSourceType('webpage')"
-            >
-              <i
-                class="i-lucide-globe text-2xl mb-2 text-slate-600 dark:text-slate-400"
-              />
-              <span
-                class="text-sm font-medium text-slate-900 dark:text-slate-100"
-              >
-                {{ t('KNOWLEDGE_SOURCE.WEBPAGE.TITLE') }}
-              </span>
-            </div>
-
-            <!-- File Option -->
-            <div
-              class="flex flex-col items-center p-4 border-2 rounded-lg cursor-pointer transition-colors"
-              :class="{
-                'border-woot-500 bg-woot-50 dark:bg-woot-900/20':
-                  selectedSourceType === 'file',
-                'border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600':
-                  selectedSourceType !== 'file',
-              }"
-              @click="selectSourceType('file')"
-            >
-              <i
-                class="i-lucide-file-text text-2xl mb-2 text-slate-600 dark:text-slate-400"
-              />
-              <span
-                class="text-sm font-medium text-slate-900 dark:text-slate-100"
-              >
-                {{ t('KNOWLEDGE_SOURCE.FILE.TITLE') }}
-              </span>
-            </div>
-
-            <!-- Image Option -->
-            <div
-              class="flex flex-col items-center p-4 border-2 rounded-lg cursor-pointer transition-colors"
-              :class="{
-                'border-woot-500 bg-woot-50 dark:bg-woot-900/20':
-                  selectedSourceType === 'image',
-                'border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600':
-                  selectedSourceType !== 'image',
-              }"
-              @click="selectSourceType('image')"
-            >
-              <i
-                class="i-lucide-image text-2xl mb-2 text-slate-600 dark:text-slate-400"
-              />
-              <span
-                class="text-sm font-medium text-slate-900 dark:text-slate-100"
-              >
-                {{ t('KNOWLEDGE_SOURCE.IMAGE.TITLE') }}
-              </span>
-            </div>
-          </div>
-        </div>
-
-        <!-- Dynamic Content Based on Selected Type -->
-
-        <!-- Webpage View -->
-        <div v-if="selectedSourceType === 'webpage'" class="space-y-4">
-          <div>
-            <label
-              class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
-            >
-              {{ t('KNOWLEDGE_SOURCE.WEBPAGE.URL_LABEL') }}
-            </label>
-            <input
-              v-model="webpageUrl"
-              type="url"
-              class="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md focus:outline-none focus:ring-2 focus:ring-woot-500 dark:bg-slate-800 dark:text-slate-100"
-              :placeholder="t('KNOWLEDGE_SOURCE.WEBPAGE.URL_PLACEHOLDER')"
-            />
-          </div>
-          <div class="flex items-center">
-            <input
-              id="crawl-subpages"
-              v-model="crawlSubpages"
-              type="checkbox"
-              class="rounded border-slate-300 text-woot-600 focus:ring-woot-500 dark:border-slate-600 dark:bg-slate-800"
-            />
-            <label
-              for="crawl-subpages"
-              class="ml-2 text-sm text-slate-700 dark:text-slate-300"
-            >
-              {{ t('KNOWLEDGE_SOURCE.WEBPAGE.CRAWL_SUBPAGES') }}
-            </label>
-          </div>
-        </div>
-
-        <!-- File View -->
-        <div v-if="selectedSourceType === 'file'" class="space-y-4">
+        <div class="space-y-4">
           <div
             class="text-center py-8 border-2 border-dashed border-slate-300 dark:border-slate-600 rounded-lg"
           >
@@ -288,35 +138,12 @@ const onUrlSubmit = async () => {
             <p class="text-sm text-slate-600 dark:text-slate-400 mb-4">
               {{ t('KNOWLEDGE_SOURCE.FILE.UPLOAD_DESCRIPTION') }}
             </p>
-            <NextButton @click="openFileBrowser">
+            <NextButton :loading="isLoading" @click="openFileBrowser">
               {{ t('KNOWLEDGE_SOURCE.FILE.BROWSE') }}
             </NextButton>
           </div>
           <p class="text-xs text-slate-500 dark:text-slate-400 text-center">
-            {{ t('KNOWLEDGE_SOURCE.FILE.SUPPORTED_TYPES') }}
-          </p>
-        </div>
-
-        <!-- Image View -->
-        <div v-if="selectedSourceType === 'image'" class="space-y-4">
-          <div
-            class="text-center py-8 border-2 border-dashed border-slate-300 dark:border-slate-600 rounded-lg"
-          >
-            <i class="i-lucide-image text-4xl text-slate-400 mb-4" />
-            <h4
-              class="text-lg font-medium text-slate-900 dark:text-slate-100 mb-2"
-            >
-              {{ t('KNOWLEDGE_SOURCE.IMAGE.UPLOAD_TITLE') }}
-            </h4>
-            <p class="text-sm text-slate-600 dark:text-slate-400 mb-4">
-              {{ t('KNOWLEDGE_SOURCE.IMAGE.UPLOAD_DESCRIPTION') }}
-            </p>
-            <NextButton @click="openFileBrowser">
-              {{ t('KNOWLEDGE_SOURCE.IMAGE.BROWSE') }}
-            </NextButton>
-          </div>
-          <p class="text-xs text-slate-500 dark:text-slate-400 text-center">
-            {{ t('KNOWLEDGE_SOURCE.IMAGE.SUPPORTED_TYPES') }}
+            {{ t('KNOWLEDGE_SOURCE.UPLOAD.SUPPORTED_TYPES') }}
           </p>
         </div>
       </div>
@@ -327,22 +154,6 @@ const onUrlSubmit = async () => {
       >
         <NextButton slate outline @click="closeModal">
           {{ t('KNOWLEDGE_SOURCE.CANCEL') }}
-        </NextButton>
-        <NextButton
-          v-if="selectedSourceType === 'webpage'"
-          :loading="isLoading"
-          :disabled="isLoading"
-          @click="onUrlSubmit"
-        >
-          {{ t('KNOWLEDGE_SOURCE.CONTINUE') }}
-        </NextButton>
-        <NextButton
-          v-else
-          :loading="isLoading"
-          :disabled="isLoading"
-          @click="openFileBrowser"
-        >
-          {{ t('KNOWLEDGE_SOURCE.ADD_SOURCE') }}
         </NextButton>
       </div>
     </div>

--- a/app/javascript/dashboard/routes/dashboard/settings/settings.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/settings.routes.js
@@ -23,6 +23,7 @@ import sla from './sla/sla.routes';
 import teams from './teams/teams.routes';
 import customRoles from './customRoles/customRole.routes';
 import profile from './profile/profile.routes';
+import prompts from './prompts/prompts.routes';
 import security from './security/security.routes';
 
 export default {
@@ -62,6 +63,7 @@ export default {
     ...teams.routes,
     ...customRoles.routes,
     ...profile.routes,
+    ...prompts.routes,
     ...security.routes,
   ],
 };

--- a/app/javascript/shared/constants/busEvents.js
+++ b/app/javascript/shared/constants/busEvents.js
@@ -16,4 +16,5 @@ export const BUS_EVENTS = {
   NEW_CONVERSATION_MODAL: 'newConversationModal',
   INSERT_INTO_RICH_EDITOR: 'insertIntoRichEditor',
   INSERT_INTO_NORMAL_EDITOR: 'insertIntoNormalEditor',
+  KNOWLEDGE_BASE_PROCESSED: 'KNOWLEDGE_BASE_PROCESSED',
 };

--- a/app/jobs/knowledge_base_processing_job.rb
+++ b/app/jobs/knowledge_base_processing_job.rb
@@ -1,0 +1,59 @@
+class KnowledgeBaseProcessingJob < ApplicationJob
+  queue_as :low
+  discard_on ActiveRecord::RecordNotFound
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
+
+  def perform(knowledge_base_id)
+    @knowledge_base = KnowledgeBase.find(knowledge_base_id)
+    @knowledge_base.update!(status: 'processing', error_message: nil)
+
+    # Clean up any chunks from a previous failed attempt to avoid duplicates on retry
+    KnowledgeBase::WeaviateService.delete_by_knowledge_base(knowledge_base: @knowledge_base)
+
+    # 1. Extract text from file/URL
+    content = KnowledgeBase::TextExtractorService.extract(@knowledge_base)
+
+    if content.blank?
+      @knowledge_base.update!(status: 'failed', error_message: 'No text content could be extracted')
+      return
+    end
+
+    # 2. Chunk the content
+    chunks = KnowledgeBase::ChunkingService.chunk(content)
+
+    if chunks.empty?
+      @knowledge_base.update!(status: 'failed', error_message: 'Content could not be chunked')
+      return
+    end
+
+    # 3. Insert chunks into Weaviate (auto-generates embeddings via text2vec-openai)
+    KnowledgeBase::WeaviateService.insert(
+      knowledge_base: @knowledge_base,
+      chunks: chunks
+    )
+
+    # 4. Update status in PostgreSQL
+    @knowledge_base.update!(
+      status: 'processed',
+      chunk_count: chunks.size,
+      processed_at: Time.current
+    )
+
+    # 5. Notify frontend via ActionCable
+    broadcast_processing_complete
+  rescue StandardError => e
+    @knowledge_base&.update(status: 'failed', error_message: e.message)
+    raise # Re-raise so Sidekiq retries
+  end
+
+  private
+
+  def broadcast_processing_complete
+    members = @knowledge_base.account.administrators.pluck(:id)
+    ActionCableBroadcastJob.perform_later(
+      members,
+      'knowledge_base.processed',
+      @knowledge_base.as_json.merge(status: @knowledge_base.status)
+    )
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -110,6 +110,7 @@ class Account < ApplicationRecord
   before_validation :validate_limit_keys
   after_create_commit :notify_creation
   after_create_commit :enqueue_stripe_provisioning_job
+  before_destroy :cleanup_weaviate_tenant
   after_destroy :remove_account_sequences
   after_destroy_commit :dispatch_destroy_event
 
@@ -239,6 +240,10 @@ class Account < ApplicationRecord
   def remove_account_sequences
     ActiveRecord::Base.connection.exec_query("drop sequence IF EXISTS camp_dpid_seq_#{id}")
     ActiveRecord::Base.connection.exec_query("drop sequence IF EXISTS conv_dpid_seq_#{id}")
+  end
+
+  def cleanup_weaviate_tenant
+    KnowledgeBase::WeaviateService.delete_tenant!(id)
   end
 end
 

--- a/app/models/account_prompt.rb
+++ b/app/models/account_prompt.rb
@@ -7,7 +7,7 @@
 #  text       :text             not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  account_id :bigint
+#  account_id :integer
 #
 # Indexes
 #

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -12,7 +12,7 @@
 #  csat_config                   :jsonb            not null
 #  csat_survey_enabled           :boolean          default(FALSE)
 #  email_address                 :string
-#  enable_auto_assignment        :boolean          default(TRUE)
+#  enable_auto_assignment        :boolean          default(FALSE)
 #  enable_email_collect          :boolean          default(TRUE)
 #  greeting_enabled              :boolean          default(FALSE)
 #  greeting_message              :string

--- a/app/models/knowledge_base.rb
+++ b/app/models/knowledge_base.rb
@@ -2,13 +2,17 @@
 #
 # Table name: knowledge_bases
 #
-#  id          :uuid             not null, primary key
-#  name        :string
-#  source_type :integer
-#  url         :string
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  account_id  :bigint           not null
+#  id            :uuid             not null, primary key
+#  chunk_count   :integer          default(0)
+#  error_message :text
+#  name          :string
+#  processed_at  :datetime
+#  source_type   :integer
+#  status        :integer          default("pending")
+#  url           :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  account_id    :integer          not null
 #
 # Indexes
 #
@@ -19,30 +23,18 @@
 #  fk_rails_...  (account_id => accounts.id)
 #
 class KnowledgeBase < ApplicationRecord
-  include Rails.application.routes.url_helpers
-
   belongs_to :account
-  has_many_attached :files
+
+  # NOTE: has_many_attached :files is incompatible with UUID primary keys
+  # (ActiveStorage's record_id is bigint). Files are accessed via the url column
+  # and the blob is looked up directly in TextExtractorService.
 
   validates :name, presence: true
   validates :account_id, presence: true
   validates :url, presence: true, if: :webpage_type?
 
   enum source_type: { webpage: 0, file: 1, image: 2 }
-
-  def file_base_data
-    files.map do |file|
-      {
-        id: file.id,
-        knowledge_base_id: id,
-        file_type: file.content_type,
-        account_id: account_id,
-        file_url: url_for(file),
-        blob_id: file.blob_id,
-        filename: file.filename.to_s
-      }
-    end
-  end
+  enum status: { pending: 0, processing: 1, processed: 2, failed: 3 }, _prefix: :status
 
   private
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -3,7 +3,7 @@
 # Table name: teams
 #
 #  id                :bigint           not null, primary key
-#  allow_auto_assign :boolean          default(TRUE)
+#  allow_auto_assign :boolean          default(FALSE)
 #  description       :text
 #  name              :string           not null
 #  created_at        :datetime         not null

--- a/app/services/knowledge_base/chunking_service.rb
+++ b/app/services/knowledge_base/chunking_service.rb
@@ -1,0 +1,61 @@
+class KnowledgeBase::ChunkingService
+  DEFAULT_CHUNK_SIZE = 500     # tokens (approx 4 chars per token)
+  DEFAULT_CHUNK_OVERLAP = 50   # tokens overlap between chunks
+  CHARS_PER_TOKEN = 4          # rough approximation
+
+  class << self
+    def chunk(text, chunk_size: DEFAULT_CHUNK_SIZE, overlap: DEFAULT_CHUNK_OVERLAP)
+      return [] if text.blank?
+
+      max_chars = chunk_size * CHARS_PER_TOKEN
+      overlap_chars = overlap * CHARS_PER_TOKEN
+
+      chunks = []
+      start_pos = 0
+
+      while start_pos < text.length
+        end_pos = start_pos + max_chars
+
+        if end_pos < text.length
+          # Find the last sentence boundary within the chunk
+          boundary = find_sentence_boundary(text, start_pos, end_pos)
+          end_pos = boundary if boundary > start_pos
+        else
+          end_pos = text.length
+        end
+
+        chunk_text = text[start_pos...end_pos].strip
+        chunks << chunk_text unless chunk_text.empty?
+
+        # Move forward by chunk size minus overlap
+        new_start = end_pos - overlap_chars
+        # Ensure forward progress to avoid infinite loop; skip overlap for last chunk
+        start_pos = if new_start <= start_pos || end_pos >= text.length
+                      end_pos
+                    else
+                      new_start
+                    end
+      end
+
+      chunks
+    end
+
+    private
+
+    def find_sentence_boundary(text, start_pos, end_pos)
+      # Look backwards from end_pos for a sentence-ending punctuation
+      search_region = text[start_pos...end_pos]
+
+      # Try to find the last sentence boundary (., !, ?, or newline)
+      last_boundary = search_region.rindex(/[.!?\n]\s/)
+      return start_pos + last_boundary + 1 if last_boundary
+
+      # Fallback: find the last space
+      last_space = search_region.rindex(' ')
+      return start_pos + last_space + 1 if last_space
+
+      # No boundary found — use the full chunk
+      end_pos
+    end
+  end
+end

--- a/app/services/knowledge_base/text_extractor_service.rb
+++ b/app/services/knowledge_base/text_extractor_service.rb
@@ -1,0 +1,149 @@
+require 'net/http'
+
+class KnowledgeBase::TextExtractorService
+  class ExtractionError < StandardError; end
+
+  class << self
+    def extract(knowledge_base)
+      case knowledge_base.source_type
+      when 'webpage'
+        extract_from_webpage(knowledge_base.url)
+      when 'file'
+        extract_from_file(knowledge_base)
+      when 'image'
+        extract_from_image(knowledge_base)
+      else
+        raise ExtractionError, "Unknown source type: #{knowledge_base.source_type}"
+      end
+    end
+
+    private
+
+    def extract_from_webpage(url)
+      uri = URI(url)
+      response = Net::HTTP.get(uri)
+      doc = Nokogiri::HTML(response)
+
+      # Remove scripts, styles, nav, footer
+      doc.css('script, style, nav, footer, header, aside').remove
+
+      # Extract text from body
+      text = doc.css('body').text
+      clean_text(text)
+    rescue StandardError => e
+      raise ExtractionError, "Failed to extract from webpage #{url}: #{e.message}"
+    end
+
+    def extract_from_file(knowledge_base)
+      # ActiveStorage's has_many_attached doesn't work with UUID primary keys
+      # (record_id is bigint). Look up the blob directly from the URL instead.
+      url = knowledge_base.url
+      raise ExtractionError, 'No file URL available' if url.blank?
+
+      # Extract blob signed_id from the ActiveStorage redirect URL and find the blob
+      blob = find_blob_from_url(url)
+      raise ExtractionError, 'Could not find file blob' unless blob
+
+      content_type = blob.content_type || detect_content_type(knowledge_base.name)
+
+      # Download blob content directly (no HTTP request needed)
+      tempfile = Tempfile.new(['kb_extract', extension_for(content_type)])
+      tempfile.binmode
+      blob.download { |chunk| tempfile.write(chunk) }
+      tempfile.rewind
+
+      text = case content_type
+             when 'application/pdf'
+               extract_pdf(tempfile.path)
+             when 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+               extract_docx(tempfile.path)
+             when 'text/plain', 'text/csv'
+               File.read(tempfile.path)
+             else
+               raise ExtractionError, "Unsupported file type: #{content_type}"
+             end
+
+      clean_text(text)
+    ensure
+      tempfile&.close
+      tempfile&.unlink
+    end
+
+    def extract_from_image(knowledge_base)
+      # For images, we generate a text description via OpenAI Vision API
+      url = knowledge_base.url
+      raise ExtractionError, 'No image URL available' if url.blank?
+
+      client = OpenAI::Client.new(access_token: ENV.fetch('OPENAI_API_KEY'))
+      response = client.chat(
+        parameters: {
+          model: 'gpt-4o-mini',
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'Describe this image in detail. Include all visible text, labels, and relevant information.' },
+                { type: 'image_url', image_url: { url: url } }
+              ]
+            }
+          ]
+        }
+      )
+
+      response.dig('choices', 0, 'message', 'content') || ''
+    rescue StandardError => e
+      raise ExtractionError, "Failed to extract from image: #{e.message}"
+    end
+
+    def extract_pdf(path)
+      reader = PDF::Reader.new(path)
+      reader.pages.map(&:text).join("\n\n")
+    end
+
+    def extract_docx(path)
+      doc = Docx::Document.open(path)
+      doc.paragraphs.map(&:text).join("\n\n")
+    end
+
+    def find_blob_from_url(url)
+      # Extract the signed_id from ActiveStorage redirect URLs like:
+      # /rails/active_storage/blobs/redirect/SIGNED_ID/filename
+      match = url.match(%r{/blobs/redirect/([^/]+)/})
+      return nil unless match
+
+      signed_id = match[1]
+      ActiveStorage::Blob.find_signed(signed_id)
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      # If signed_id is invalid, try finding by filename
+      filename = url.split('/').last
+      ActiveStorage::Blob.find_by(filename: filename)
+    end
+
+    def detect_content_type(filename)
+      ext = File.extname(filename).downcase
+      {
+        '.pdf' => 'application/pdf',
+        '.docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        '.doc' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        '.txt' => 'text/plain',
+        '.csv' => 'text/csv'
+      }.fetch(ext, 'application/octet-stream')
+    end
+
+    def extension_for(content_type)
+      {
+        'application/pdf' => '.pdf',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => '.docx',
+        'text/plain' => '.txt',
+        'text/csv' => '.csv'
+      }.fetch(content_type, '.tmp')
+    end
+
+    def clean_text(text)
+      text
+        .gsub(/\n{3,}/, "\n\n")     # collapse excessive newlines first
+        .gsub(/[^\S\n]+/, ' ')      # collapse horizontal whitespace (spaces, tabs) but preserve newlines
+        .strip
+    end
+  end
+end

--- a/app/services/knowledge_base/weaviate_service.rb
+++ b/app/services/knowledge_base/weaviate_service.rb
@@ -1,0 +1,121 @@
+require 'weaviate'
+
+class KnowledgeBase::WeaviateService
+  COLLECTION_NAME = 'KnowledgeBaseChunk'.freeze
+
+  class << self
+    # Initialize the Weaviate Cloud client
+    def client
+      @client ||= Weaviate::Client.new(
+        url: ENV.fetch('WEAVIATE_URL'),           # e.g., https://your-cluster-id.weaviate.cloud
+        api_key: ENV.fetch('WEAVIATE_API_KEY'),    # Weaviate Cloud API key
+        model_service: :openai,
+        model_service_api_key: ENV.fetch('OPENAI_API_KEY')
+      )
+    end
+
+    # Create the collection schema (run once during setup)
+    # Uses direct Faraday call because weaviate-ruby gem doesn't pass
+    # multi_tenant and module_config params correctly
+    def setup_collection!
+      connection = Faraday.new(url: ENV.fetch('WEAVIATE_URL')) do |f|
+        f.request :json
+        f.response :raise_error
+        f.adapter Faraday.default_adapter
+      end
+
+      connection.post('/v1/schema') do |req|
+        req.headers['Authorization'] = "Bearer #{ENV.fetch('WEAVIATE_API_KEY')}"
+        req.headers['X-OpenAI-Api-Key'] = ENV.fetch('OPENAI_API_KEY')
+        req.headers['Content-Type'] = 'application/json'
+        req.body = {
+          class: COLLECTION_NAME,
+          description: 'Knowledge base text chunks for RAG',
+          vectorizer: 'text2vec-openai',
+          moduleConfig: {
+            'text2vec-openai' => {},
+            'generative-openai' => {}
+          },
+          multiTenancyConfig: { enabled: true },
+          properties: [
+            { name: 'content', dataType: ['text'], description: 'Chunk text content' },
+            { name: 'knowledge_base_id', dataType: ['text'], description: 'FK to PostgreSQL knowledge_bases' },
+            { name: 'chunk_index', dataType: ['int'], description: 'Position within source document' },
+            { name: 'source_type', dataType: ['text'], description: 'webpage, file, or image' },
+            { name: 'source_name', dataType: ['text'], description: 'Original filename or URL' }
+          ]
+        }
+      end
+    end
+
+    # Ensure tenant exists for an account
+    def ensure_tenant!(account_id)
+      tenant_name = tenant_for(account_id)
+      client.schema.add_tenants(
+        class_name: COLLECTION_NAME,
+        tenants: [tenant_name]
+      )
+    rescue StandardError => e
+      # Tenant already exists — safe to ignore (Weaviate returns 422 via Faraday)
+      raise unless e.message.include?('already exists') || e.message.include?('422')
+    end
+
+    # Insert chunks into Weaviate (auto-generates embeddings)
+    def insert(knowledge_base:, chunks:)
+      tenant_name = tenant_for(knowledge_base.account_id)
+      ensure_tenant!(knowledge_base.account_id)
+
+      objects = chunks.each_with_index.map do |chunk_text, index|
+        {
+          class: COLLECTION_NAME,
+          tenant: tenant_name,
+          properties: {
+            content: chunk_text,
+            knowledge_base_id: knowledge_base.id.to_s,
+            chunk_index: index,
+            source_type: knowledge_base.source_type,
+            source_name: knowledge_base.name
+          }
+        }
+      end
+
+      # Batch insert (Weaviate auto-vectorizes each chunk via text2vec-openai)
+      client.objects.batch_create(objects: objects)
+    end
+
+    # Delete all chunks for a specific knowledge base
+    # Rescues broadly so Weaviate failures don't block KB deletion
+    def delete_by_knowledge_base(knowledge_base:)
+      tenant_name = tenant_for(knowledge_base.account_id)
+
+      client.objects.batch_delete(
+        class_name: COLLECTION_NAME,
+        tenant: tenant_name,
+        where: {
+          path: ['knowledge_base_id'],
+          operator: 'Equal',
+          valueText: knowledge_base.id.to_s
+        }
+      )
+    rescue StandardError => e
+      Rails.logger.warn("Weaviate delete failed for KB #{knowledge_base.id}: #{e.message}")
+    end
+
+    # Delete entire tenant (all data for an account)
+    # Rescues broadly so Weaviate failures don't block account deletion
+    def delete_tenant!(account_id)
+      client.schema.remove_tenants(
+        class_name: COLLECTION_NAME,
+        tenants: [tenant_for(account_id)]
+      )
+    rescue StandardError => e
+      Rails.logger.warn("Weaviate tenant delete failed for account #{account_id}: #{e.message}")
+    end
+
+    private
+
+    def tenant_for(account_id)
+      "account_#{account_id}"
+    end
+  end
+end

--- a/config/features.yml
+++ b/config/features.yml
@@ -227,3 +227,6 @@
   display_name: Contacts
   enabled: true
   tier: community
+- name: prompts
+  display_name: Knowledge Base
+  enabled: true

--- a/db/migrate_custom/20260330002518_add_processing_status_to_knowledge_bases.rb
+++ b/db/migrate_custom/20260330002518_add_processing_status_to_knowledge_bases.rb
@@ -1,0 +1,8 @@
+class AddProcessingStatusToKnowledgeBases < ActiveRecord::Migration[7.1]
+  def change
+    add_column :knowledge_bases, :status, :integer, default: 0, if_not_exists: true
+    add_column :knowledge_bases, :error_message, :text, if_not_exists: true
+    add_column :knowledge_bases, :chunk_count, :integer, default: 0, if_not_exists: true
+    add_column :knowledge_bases, :processed_at, :datetime, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_11_19_161025) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_11_170500) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"

--- a/db/schema_custom.rb
+++ b/db/schema_custom.rb
@@ -5,9 +5,9 @@
 # This file documents the schema for custom business-specific tables
 # that are separate from upstream Chatwoot tables.
 #
-# Current custom migration version: 20260311170500
+# Current custom migration version: none
 
-ActiveRecord::Schema[7.1].define(version: 20_260_311_170_500) do
+ActiveRecord::Schema[7.1].define(version: 0) do
   enable_extension 'pgcrypto'
 
   create_table :account_prompts, id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|

--- a/lib/tasks/weaviate.rake
+++ b/lib/tasks/weaviate.rake
@@ -1,0 +1,14 @@
+namespace :weaviate do
+  desc 'Create the KnowledgeBaseChunk collection in Weaviate'
+  task setup: :environment do
+    puts 'Creating Weaviate collection...'
+    KnowledgeBase::WeaviateService.setup_collection!
+    puts 'Done.'
+  rescue Weaviate::Error => e
+    if e.message.include?('already exists')
+      puts 'Collection already exists — skipping.'
+    else
+      raise
+    end
+  end
+end

--- a/spec/models/knowledge_base_spec.rb
+++ b/spec/models/knowledge_base_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe KnowledgeBase do
 
   describe 'associations' do
     it { is_expected.to belong_to(:account) }
-    it { is_expected.to have_many_attached(:files) }
   end
 
   describe 'enums' do


### PR DESCRIPTION
## Summary

Implements a complete RAG (Retrieval-Augmented Generation) knowledge base pipeline that allows account administrators to upload files (PDF, DOCX, TXT, CSV, images) from the Chatwoot dashboard. Files are processed asynchronously via Sidekiq — text is extracted, chunked, and inserted into Weaviate Cloud with auto-generated vector embeddings for future semantic search and RAG during conversations.

## Changes

### Backend (Write Path)
- Added `KnowledgeBase::WeaviateService` — handles collection setup, tenant management, chunk insertion, and deletion against Weaviate Cloud
- Added `KnowledgeBase::TextExtractorService` — extracts text from PDFs, DOCX, TXT/CSV files, and images (OpenAI Vision API)
- Added `KnowledgeBase::ChunkingService` — sentence-boundary-aware text chunking with configurable size and overlap
- Added `KnowledgeBaseProcessingJob` — Sidekiq job orchestrating the extract → chunk → insert pipeline with retry logic and ActionCable broadcast on completion
- Added `weaviate:setup` rake task for one-time Weaviate Cloud collection creation

### Model & Controller
- Added `status` enum (pending, processing, processed, failed) to KnowledgeBase model
- Added `error_message`, `chunk_count`, `processed_at` columns via custom migration
- Removed `has_many_attached :files` (incompatible with UUID primary keys)
- Updated controller: enqueue job in create, Weaviate cleanup in destroy, string status in API response
- Added `before_destroy :cleanup_weaviate_tenant` to Account model

### Frontend
- Added `prompts` feature flag and registered routes in settings
- Merged File and Image upload into a single upload flow with auto-detection
- Added processing status badges (Pending/Processing/Added/Failed)
- Added 5-second auto-polling while any KB is processing
- Added ActionCable event wiring for real-time status updates
- Added i18n translations for EN and ES

### Infrastructure
- Added `weaviate-ruby`, `pdf-reader`, `docx` gems
- Added `WEAVIATE_URL`, `WEAVIATE_API_KEY`, `OPENAI_API_KEY` env vars

## Technical Notes
- Weaviate Cloud (managed SaaS) used as vector store with `text2vec-openai` auto-vectorization and multi-tenancy
- The `weaviate-ruby` gem `schema.create` does not correctly pass multi-tenancy and module config — `setup_collection!` uses a direct Faraday POST as a workaround
- ActiveStorage `has_many_attached` is incompatible with UUID primary keys — files accessed via URL and blob lookup instead
- Query/RAG path is NOT in this PR — belongs in the ChatsCommerce Python backend

## Testing
1. Navigate to Settings then Knowledge Base
2. Upload a PDF — status should auto-update from Pending to Added
3. Verify chunks in Weaviate Cloud console under the account tenant
4. Delete the KB — verify removal from both Postgres and Weaviate Cloud

## Related
- Ticket: CU-86ag5q3ck