### PR TITLE
CU-86agnv7t2_Onboarding-Self-Leaning-Front-End-UI-provisional (Provisional)

### DIFF
--- a/app/controllers/api/v1/accounts/ai_chat_controller.rb
+++ b/app/controllers/api/v1/accounts/ai_chat_controller.rb
@@ -15,7 +15,8 @@ class Api::V1::Accounts::AiChatController < Api::V1::Accounts::BaseController
       user_id: Current.user.id,
       agent_bot_id: @agent_bot.id,
       message: @message_content,
-      chat_session_id: params[:chat_session_id]
+      chat_session_id: params[:chat_session_id],
+      chat_mode: params[:chat_mode] || 'admin'
     ) do |chunk, session_id|
       # Set session ID header (before first write commits headers)
       if session_id.present? && !session_id_set

--- a/app/javascript/dashboard/components-next/ai-assistant/AiAssistant.vue
+++ b/app/javascript/dashboard/components-next/ai-assistant/AiAssistant.vue
@@ -46,6 +46,8 @@ const panels = {
 
 const {
   chat,
+  chatMode,
+  toggleChatMode,
   selectedBotId,
   availableBots,
   botsLoading,
@@ -97,6 +99,7 @@ const layoutProps = computed(() => {
     v-if="layout === 'inline'"
     v-model:selected-bot-id="selectedBotId"
     :chat="chat"
+    :chat-mode="chatMode"
     :title="chatTitle"
     :disabled="isDisabled"
     :bots="availableBots"
@@ -112,6 +115,7 @@ const layoutProps = computed(() => {
     @new-session="startNewSession"
     @delete-session="deleteSession"
     @fetch-sessions="fetchSessions"
+    @toggle-chat-mode="toggleChatMode"
   />
 
   <!-- Panel layouts (floating, sidebar) -->
@@ -130,6 +134,7 @@ const layoutProps = computed(() => {
       <AiChatPanel
         v-model:selected-bot-id="selectedBotId"
         :chat="chat"
+        :chat-mode="chatMode"
         :title="chatTitle"
         :disabled="isDisabled"
         :bots="availableBots"
@@ -145,6 +150,7 @@ const layoutProps = computed(() => {
         @new-session="startNewSession"
         @delete-session="deleteSession"
         @fetch-sessions="fetchSessions"
+        @toggle-chat-mode="toggleChatMode"
         @close="close"
       />
     </template>

--- a/app/javascript/dashboard/components-next/ai-assistant/chatwootChatConfig.ts
+++ b/app/javascript/dashboard/components-next/ai-assistant/chatwootChatConfig.ts
@@ -22,6 +22,7 @@ import { isTextPart, type MessagePart, type TextPart } from './types';
 import { parseSessionsResponse, parseMessagesResponse } from './schemas';
 import { LocalStorage } from 'shared/helpers/localStorage';
 import type { UIMessage } from 'ai';
+import type { ChatMode } from './constants';
 
 // ============================================================================
 // Helper Functions
@@ -64,6 +65,7 @@ export function createChatwootTransportConfig(
   getMetadata: () => {
     agentBotId: number | null;
     sessionId: string | null;
+    chatMode?: ChatMode;
   },
 ): TransportConfig {
   return {
@@ -78,6 +80,7 @@ export function createChatwootTransportConfig(
           },
         ],
         agent_bot_id: metadata.agentBotId ?? getMetadata().agentBotId,
+        chat_mode: metadata.chatMode ?? getMetadata().chatMode ?? 'admin',
         ...(metadata.sessionId ?? getMetadata().sessionId
           ? {
               chat_session_id:

--- a/app/javascript/dashboard/components-next/ai-assistant/composables/useAiAssistant.ts
+++ b/app/javascript/dashboard/components-next/ai-assistant/composables/useAiAssistant.ts
@@ -8,7 +8,7 @@
  * All Chatwoot-specific transport/session logic is injected via
  * chatwootChatConfig factories — composables are framework-agnostic.
  */
-import { computed, onMounted, watch } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { useStore } from 'dashboard/composables/store';
 import { useAiChat } from './useAiChat';
@@ -20,6 +20,8 @@ import {
   createChatwootPersistenceAdapter,
   chatwootBehaviorConfig,
 } from '../chatwootChatConfig';
+import { CHAT_MODE } from '../constants';
+import type { ChatMode } from '../constants';
 
 export function useAiAssistant() {
   const route = useRoute();
@@ -55,6 +57,16 @@ export function useAiAssistant() {
       : null;
   });
 
+  // Chat mode: admin (regular) or onboarding
+  const chatMode = ref<ChatMode>(CHAT_MODE.ADMIN);
+
+  const toggleChatMode = () => {
+    chatMode.value =
+      chatMode.value === CHAT_MODE.ADMIN
+        ? CHAT_MODE.ONBOARDING
+        : CHAT_MODE.ADMIN;
+  };
+
   // Bot selection — delegated to useAIChatBot
   const {
     selectedBotId,
@@ -84,6 +96,7 @@ export function useAiAssistant() {
     () => ({
       agentBotId: selectedBotId.value,
       sessionId: sessionManager.activeSessionId.value,
+      chatMode: chatMode.value,
     }),
   );
 
@@ -144,6 +157,10 @@ export function useAiAssistant() {
   return {
     // Chat instance
     chat,
+
+    // Chat mode
+    chatMode,
+    toggleChatMode,
 
     // Bot state
     selectedBotId,

--- a/app/javascript/dashboard/components-next/ai-assistant/constants.ts
+++ b/app/javascript/dashboard/components-next/ai-assistant/constants.ts
@@ -77,6 +77,16 @@ export const MESSAGE_ROLE = MESSAGE_ROLES;
 
 export type MessageRole = (typeof MESSAGE_ROLES)[keyof typeof MESSAGE_ROLES];
 
+/**
+ * Chat modes - determines which AI Backend workflow to use
+ */
+export const CHAT_MODE = {
+  ADMIN: 'admin',
+  ONBOARDING: 'onboarding',
+} as const;
+
+export type ChatMode = (typeof CHAT_MODE)[keyof typeof CHAT_MODE];
+
 export const VOICE_INPUT_STATUS = {
   IDLE: 'idle',
   RECORDING: 'recording',

--- a/app/javascript/dashboard/components-next/ai-assistant/containers/AiChatHeader.vue
+++ b/app/javascript/dashboard/components-next/ai-assistant/containers/AiChatHeader.vue
@@ -12,11 +12,12 @@ import { computed } from 'vue';
 import { useAiI18n } from '../i18n/aiChatI18n';
 import { useToggle } from '@vueuse/core';
 import { OnClickOutside } from '@vueuse/components';
-import { CHAT_STATUS } from '../constants';
+import { CHAT_STATUS, CHAT_MODE } from '../constants';
 
 const props = defineProps({
   title: { type: String, default: null },
   status: { type: String, required: true },
+  chatMode: { type: String, default: 'admin' },
   isLoading: { type: Boolean, default: false },
   bots: { type: Array, default: () => [] },
   botsLoading: { type: Boolean, default: false },
@@ -27,11 +28,32 @@ const props = defineProps({
 const emit = defineEmits([
   'update:selectedBotId',
   'toggleSessionHistory',
+  'toggleChatMode',
   'newSession',
   'close',
 ]);
 
 const { t } = useAiI18n();
+
+const isOnboardingMode = computed(
+  () => props.chatMode === CHAT_MODE.ONBOARDING
+);
+
+const chatModeLabel = computed(() =>
+  isOnboardingMode.value
+    ? t('AI_CHAT.MODE.ONBOARDING')
+    : t('AI_CHAT.MODE.ADMIN')
+);
+
+const chatModeIcon = computed(() =>
+  isOnboardingMode.value ? 'i-lucide-graduation-cap' : 'i-lucide-message-square'
+);
+
+const chatModeButtonText = computed(() =>
+  isOnboardingMode.value
+    ? t('AI_CHAT.MODE.ONBOARDING_LABEL')
+    : t('AI_CHAT.MODE.ADMIN_LABEL')
+);
 
 const showBotSelector = computed(() => props.bots.length > 0);
 
@@ -160,6 +182,22 @@ const headerTitle = computed(() => props.title || t('AI_CHAT.HEADER.TITLE'));
         </h2>
       </div>
       <div class="flex items-center gap-1 flex-shrink-0">
+        <!-- Chat Mode toggle -->
+        <button
+          v-tooltip="chatModeLabel"
+          :aria-label="chatModeLabel"
+          :disabled="isLoading"
+          class="flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          :class="
+            isOnboardingMode
+              ? 'bg-n-teal-3 text-n-teal-11 hover:bg-n-teal-4'
+              : 'bg-n-amber-3 text-n-amber-11 hover:bg-n-amber-4'
+          "
+          @click="emit('toggleChatMode')"
+        >
+          <span :class="chatModeIcon" class="size-4" />
+          <span>{{ chatModeButtonText }}</span>
+        </button>
         <!-- New Chat button -->
         <button
           v-tooltip="t('AI_CHAT.SESSIONS.NEW_CHAT')"

--- a/app/javascript/dashboard/components-next/ai-assistant/containers/AiChatPanel.vue
+++ b/app/javascript/dashboard/components-next/ai-assistant/containers/AiChatPanel.vue
@@ -37,6 +37,7 @@ import AiChatError from '../feedback/AiChatError.vue';
 
 const props = defineProps({
   chat: { type: Object, required: true },
+  chatMode: { type: String, default: 'admin' },
   showHeader: { type: Boolean, default: true },
   title: { type: String, default: null },
   disabled: { type: Boolean, default: false },
@@ -57,6 +58,7 @@ const emit = defineEmits([
   'newSession',
   'deleteSession',
   'fetchSessions',
+  'toggleChatMode',
 ]);
 
 const renderMarkdown = text => new MessageFormatter(text).formattedMessage;
@@ -238,6 +240,7 @@ const handleFreshStart = () => {
       v-if="showHeader"
       :title="title"
       :status="chatStatus"
+      :chat-mode="chatMode"
       :is-loading="isLoading"
       :bots="bots"
       :bots-loading="botsLoading"
@@ -245,6 +248,7 @@ const handleFreshStart = () => {
       :show-session-history="showSessionHistory"
       @update:selected-bot-id="handleBotSelect"
       @toggle-session-history="toggleSessionHistory"
+      @toggle-chat-mode="emit('toggleChatMode')"
       @new-session="handleNewSession"
       @close="emit('close')"
     />

--- a/app/javascript/dashboard/components-next/ai-assistant/i18n/aiChatI18n.ts
+++ b/app/javascript/dashboard/components-next/ai-assistant/i18n/aiChatI18n.ts
@@ -65,6 +65,10 @@ const defaultStrings: Record<string, string> = {
   'AI_CHAT.SESSIONS.TODAY': 'Today',
   'AI_CHAT.SESSIONS.YESTERDAY': 'Yesterday',
   'AI_CHAT.COLLAPSIBLE.COLLAPSE': 'Collapse',
+  'AI_CHAT.MODE.ADMIN': 'Switch to Admin mode',
+  'AI_CHAT.MODE.ONBOARDING': 'Switch to Onboarding mode',
+  'AI_CHAT.MODE.ADMIN_LABEL': 'Admin',
+  'AI_CHAT.MODE.ONBOARDING_LABEL': 'Onboarding',
 };
 
 const defaultI18n: I18nProvider = {

--- a/app/javascript/dashboard/i18n/locale/en/aiChat.json
+++ b/app/javascript/dashboard/i18n/locale/en/aiChat.json
@@ -98,6 +98,12 @@
     },
     "COLLAPSIBLE": {
       "COLLAPSE": "Collapse"
+    },
+    "MODE": {
+      "ADMIN": "Switch to Admin mode",
+      "ONBOARDING": "Switch to Onboarding mode",
+      "ADMIN_LABEL": "Admin",
+      "ONBOARDING_LABEL": "Onboarding"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/locale/es/aiChat.json
+++ b/app/javascript/dashboard/i18n/locale/es/aiChat.json
@@ -98,6 +98,12 @@
     },
     "COLLAPSIBLE": {
       "COLLAPSE": "Colapsar"
+    },
+    "MODE": {
+      "ADMIN": "Cambiar a modo Admin",
+      "ONBOARDING": "Cambiar a modo Onboarding",
+      "ADMIN_LABEL": "Admin",
+      "ONBOARDING_LABEL": "Onboarding"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/locale_custom/en/aiChat.json
+++ b/app/javascript/dashboard/i18n/locale_custom/en/aiChat.json
@@ -98,6 +98,12 @@
     },
     "COLLAPSIBLE": {
       "COLLAPSE": "Collapse"
+    },
+    "MODE": {
+      "ADMIN": "Switch to Admin mode",
+      "ONBOARDING": "Switch to Onboarding mode",
+      "ADMIN_LABEL": "Admin",
+      "ONBOARDING_LABEL": "Onboarding"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/locale_custom/es/aiChat.json
+++ b/app/javascript/dashboard/i18n/locale_custom/es/aiChat.json
@@ -98,6 +98,12 @@
     },
     "COLLAPSIBLE": {
       "COLLAPSE": "Colapsar"
+    },
+    "MODE": {
+      "ADMIN": "Cambiar a modo Admin",
+      "ONBOARDING": "Cambiar a modo Onboarding",
+      "ADMIN_LABEL": "Admin",
+      "ONBOARDING_LABEL": "Onboarding"
     }
   }
 }

--- a/app/javascript/dashboard/routes/dashboard/Dashboard.vue
+++ b/app/javascript/dashboard/routes/dashboard/Dashboard.vue
@@ -83,12 +83,7 @@ export default {
       return showSecondarySidebar;
     },
     canUseAI() {
-      // AI assistant disabled — not yet ready for production
-      return false;
-      // Uncomment this if you want to restrict AI assistant to only certain users
-      // return window.chatwootConfig?.features?.includes('ai_assistant') &&
-      //        window.chatwootConfig?.aiAssistantEnabled &&
-      //        process.env.NODE_ENV !== 'test'; // Don't show in tests
+      return true;
     },
   },
   watch: {

--- a/app/services/ai_backend_service/agent_system_messaging_service.rb
+++ b/app/services/ai_backend_service/agent_system_messaging_service.rb
@@ -215,7 +215,7 @@ module AiBackendService
     # @param chat_session_id [String, nil] Optional session ID
     # @yield [chunk, session_id] Yields each SSE chunk and session_id (from headers)
     # @return [void]
-    def stream_message(account_id:, user_id:, agent_bot_id:, message:, chat_session_id: nil)
+    def stream_message(account_id:, user_id:, agent_bot_id:, message:, chat_session_id: nil, chat_mode: 'admin')
       raise ArgumentError, 'Block required for streaming' unless block_given?
 
       body = build_request_body(message, user_id, chat_session_id)
@@ -223,7 +223,7 @@ module AiBackendService
 
       log_request('stream_message', account_id, user_id, agent_bot_id, chat_session_id)
 
-      uri = build_stream_uri(query_params)
+      uri = build_stream_uri(query_params, chat_mode: chat_mode)
       session_id = nil
       chunk_count = 0
 
@@ -294,8 +294,11 @@ module AiBackendService
     end
 
     # Build URI for streaming endpoint
-    def build_stream_uri(query_params)
-      uri = URI("#{ai_backend_api_url}/api/messaging/agent-systems/message/stream")
+    # Routes to onboarding endpoint when chat_mode is 'onboarding'
+    def build_stream_uri(query_params, chat_mode: 'admin')
+      base = '/api/messaging/agent-systems'
+      path = chat_mode == 'onboarding' ? "#{base}/onboarding/message/stream" : "#{base}/message/stream"
+      uri = URI("#{ai_backend_api_url}#{path}")
       uri.query = URI.encode_www_form(query_params)
       uri
     end


### PR DESCRIPTION
## Summary
Add a mode toggle button to the AI Assistant chat header that allows admins to switch
between "Admin" (regular orchestrator) and "Onboarding" (onboarding orchestrator) workflows.
The mode selection routes messages to the corresponding AI Backend endpoint, enabling the
onboarding conversation flow from the same chat panel.

## Changes
- Added `CHAT_MODE` constant (`admin` | `onboarding`) to the AI chat constants
- Added `chatMode` ref and `toggleChatMode()` to the `useAiAssistant` composable
- Included `chat_mode` in the stream request body via `chatwootChatConfig`
- Added a toggle pill button in the chat header (green for onboarding, yellow for admin)
- Backend controller passes `chat_mode` param to the messaging service
- Messaging service routes to `/onboarding/message/stream` when mode is `onboarding`
- Added i18n keys for mode labels in EN and ES (locale + locale_custom)

## Technical Notes
- The AI Backend already exposes separate endpoints for each workflow:
  - Admin: `POST /api/messaging/agent-systems/message/stream`
  - Onboarding: `POST /api/messaging/agent-systems/onboarding/message/stream`
- The mode toggle threads through the full stack: UI → transport config → controller → service → AI Backend URL
- Default mode is `admin` to preserve existing behavior

## Testing
- Open the AI Assistant floating panel
- Verify the mode toggle button appears in the header action bar
- Click the toggle: should switch between "Admin" (yellow) and "Onboarding" (green)
- Send a message in each mode and verify the backend routes to the correct AI Backend endpoint
- Verify the button is disabled during streaming

## Related
- Ticket: CU-86agnv7t2
